### PR TITLE
chore: don't match "managed-by: Helm" label

### DIFF
--- a/charts/im-backup/Chart.yaml
+++ b/charts/im-backup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/im-backup/templates/schedule.yaml
+++ b/charts/im-backup/templates/schedule.yaml
@@ -27,8 +27,6 @@ spec:
               - cluster-apps
       - matchLabels:
           owner: helm
-      - matchLabels:
-          app.kubernetes.io/managed-by: Helm
     snapshotVolumes: true
     ttl: {{ .Values.ttl }}
   useOwnerReferencesInBackup: false


### PR DESCRIPTION
We don't want to match the `app.kubernetes.io/managed-by=Helm` label, as this will include the IM instances PVCs into the Velero backup.